### PR TITLE
influxdb: Add support for influxdb v0.9.x with clustering and replication

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,11 +11,11 @@ RUN echo 'deb http://http.debian.net/debian wheezy-backports main' >> /etc/apt/s
        rpm build-essential git wget gawk \
     && curl -sSL https://get.docker.io/ | sh
 
-#checkout InfluxDB version 0.8.6
+#checkout InfluxDB version 0.8.8
 RUN mkdir -p $GOPATH/src/github.com/influxdb && \
  cd $GOPATH/src/github.com/influxdb && \
  git clone https://github.com/influxdb/influxdb.git && \
- cd influxdb && git checkout tags/v0.8.6
+ cd influxdb && git checkout tags/v0.8.8
 
 WORKDIR $GOPATH/src/github.com/influxdb/influxdb
 

--- a/config.toml
+++ b/config.toml
@@ -114,7 +114,7 @@ lru-cache-size = "200m"
 
 # The default setting on this is 0, which means unlimited. Set this to something if you want to
 # limit the max number of open files. max-open-files is per shard so this * that will be max.
-max-open-shards = 0
+max-open-shards = 20
 
 # The default setting is 100. This option tells how many points will be fetched from LevelDb before
 # they get flushed into backend.

--- a/config.toml
+++ b/config.toml
@@ -63,6 +63,9 @@ dir = "/data/influxdb/development/db"
 # will be replayed from the WAL
 write-buffer-size = 10000
 
+# The server will check this often for shards that have expired and should be cleared.
+retention-sweep-period = "10m"
+
 [cluster]
 # A comma separated list of servers to seed
 # this server. this is only relevant when the
@@ -114,7 +117,7 @@ lru-cache-size = "200m"
 
 # The default setting on this is 0, which means unlimited. Set this to something if you want to
 # limit the max number of open files. max-open-files is per shard so this * that will be max.
-max-open-shards = 0
+max-open-shards = 5
 
 # The default setting is 100. This option tells how many points will be fetched from LevelDb before
 # they get flushed into backend.

--- a/config.toml
+++ b/config.toml
@@ -117,7 +117,7 @@ lru-cache-size = "200m"
 
 # The default setting on this is 0, which means unlimited. Set this to something if you want to
 # limit the max number of open files. max-open-files is per shard so this * that will be max.
-max-open-shards = 20
+max-open-shards = 1000
 
 # The default setting is 100. This option tells how many points will be fetched from LevelDb before
 # they get flushed into backend.

--- a/config.toml
+++ b/config.toml
@@ -17,7 +17,7 @@ reporting-disabled = false
 
 [logging]
 # logging level can be one of "debug", "info", "warn" or "error"
-level  = "warn"
+level  = "info"
 file   = "/data/influxdb/influxdb.log"         # stdout to log to standard out
 
 # Configure the admin server

--- a/config.toml
+++ b/config.toml
@@ -17,7 +17,7 @@ reporting-disabled = false
 
 [logging]
 # logging level can be one of "debug", "info", "warn" or "error"
-level  = "info"
+level  = "warn"
 file   = "/data/influxdb/influxdb.log"         # stdout to log to standard out
 
 # Configure the admin server

--- a/run_influxdb
+++ b/run_influxdb
@@ -2,9 +2,6 @@
 
 CONFIG_FILE="/etc/influxdb/config.toml"
 
-#Dynamically change the value of 'max-open-shards' to what 'ulimit -n' returns
-sed -i "s/^max-open-shards.*/max-open-shards = $(ulimit -n)/g" ${CONFIG_FILE}
-
 #Configure InfluxDB Cluster
 if [ -n "${HOSTNAME}" ]; then
 	if [ "${HOSTNAME}" == "auto" ]; then

--- a/run_influxdb
+++ b/run_influxdb
@@ -23,4 +23,4 @@ fi
 
 echo "=> Starting InfluxDB ..."
 
-exec /usr/bin/influxdb -config=/etc/influxdb/config.toml
+exec /usr/bin/influxdb -config=/etc/influxdb/config.toml -stdout

--- a/v0.9.x/Dockerfile
+++ b/v0.9.x/Dockerfile
@@ -1,0 +1,34 @@
+FROM debian:jessie
+
+RUN apt-get update && apt-get install -y curl
+
+# Install InfluxDB
+ENV INFLUXDB_VERSION 0.9.2-rc1
+RUN curl -s -o /tmp/influxdb_latest_amd64.deb https://s3.amazonaws.com/influxdb/influxdb_${INFLUXDB_VERSION}_amd64.deb && \
+  dpkg -i /tmp/influxdb_latest_amd64.deb && \
+  rm /tmp/influxdb_latest_amd64.deb && \
+  rm -rf /var/lib/apt/lists/*
+
+ADD influxdb.conf /config/influxdb.conf
+ADD run.sh /run.sh
+RUN chmod +x /*.sh
+
+ENV SSL_SUPPORT **False**
+ENV SSL_CERT **None**
+
+# Admin server
+EXPOSE 8083
+
+# HTTP API
+EXPOSE 8086
+
+# Clustering
+EXPOSE 8088
+
+# Raft port (for clustering, don't expose publicly!)
+#EXPOSE 8090
+
+# Protobuf port (for clustering, don't expose publicly!)
+#EXPOSE 8099
+
+CMD ["/run.sh"]

--- a/v0.9.x/influxdb.conf
+++ b/v0.9.x/influxdb.conf
@@ -1,0 +1,105 @@
+reporting-disabled = false
+
+[meta]
+  dir = "/var/opt/influxdb/meta"
+  hostname = "localhost"
+  bind-address = ":8088"
+  retention-autocreate = true
+  election-timeout = "1s"
+  heartbeat-timeout = "1s"
+  leader-lease-timeout = "500ms"
+  commit-timeout = "50ms"
+  peers = ""
+
+[logging]
+  write-tracing = false
+  level  = "info"
+  file   = "/opt/influxdb/shared/log.txt"
+
+[data]
+  dir = "/data/influxdb"
+  max-wal-size = 104857600
+  wal-flush-interval = "10m0s"
+  wal-partition-flush-delay = "2s"
+  retention-auto-create = true
+  retention-check-enabled = true
+  retention-check-period = "10m0s"
+  retention-create-period = "45m0s"
+
+[cluster]
+  shard-writer-timeout = "5s"
+
+[retention]
+  replication = 1
+  enabled = true
+  check-interval = "10m0s"
+
+[shard-precreation]
+  enabled = true
+  check-interval = "10m0s"
+  advance-period = "30m0s"
+
+[admin]
+  enabled = true
+  bind-address = "0.0.0.0:8083"
+  assets = "/opt/influxdb/current/admin"
+
+[http]
+  enabled = true
+  bind-address = "0.0.0.0:8086"
+  auth-enabled = false
+  log-enabled = true
+  write-tracing = false
+  pprof-enabled = false
+
+[[graphite]]
+  bind-address = ":2003"
+  database = "graphite"
+  enabled = false
+  protocol = "tcp"
+  batch-size = 0
+  batch-timeout = "0"
+  consistency-level = "one"
+  separator = "."
+
+[collectd]
+  enabled = false
+  bind-address = ":25826"
+  database = "collectd"
+  retention-policy = ""
+  batch-size = 5000
+  batch-timeout = "10s"
+  typesdb = "/usr/share/collectd/types.db"
+
+[opentsdb]
+  enabled = false
+  bind-address = ":4242"
+  database = "opentsdb"
+  retention-policy = ""
+  consistency-level = "one"
+
+[udp]
+  enabled = false
+  bind-address = ""
+  database = ""
+  batch-size = 0
+  batch-timeout = "0"
+
+[monitoring]
+  enabled = false
+  write-interval = "1m0s"
+
+[continuous_queries]
+  enabled = true
+  recompute-previous-n = 2
+  recompute-no-older-than = "10m0s"
+  compute-runs-per-interval = 10
+  compute-no-more-than = "2m0s"
+
+[hinted-handoff]
+  enabled = true
+  dir = "/var/opt/influxdb/hh"
+  max-size = 1073741824
+  max-age = "168h0m0s"
+  retry-rate-limit = 0
+  retry-interval = "1s"

--- a/v0.9.x/run.sh
+++ b/v0.9.x/run.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -m
+CONFIG_FILE="/config/influxdb.conf"
+
+# Dynamically change the value of 'max-open-shards' to what 'ulimit -n' returns
+sed -i "s/^max-open-shards.*/max-open-shards = $(ulimit -n)/" ${CONFIG_FILE}
+
+# Configure InfluxDB Cluster
+if [ -n "${FORCE_HOSTNAME}" ]; then
+    if [ "${FORCE_HOSTNAME}" == "auto" ]; then
+        #set hostname with IPv4 eth0
+        HOSTIPNAME=$(ip a show dev eth0 | grep inet | grep eth0 | sed -e 's/^.*inet.//g' -e 's/\/.*$//g')
+        /usr/bin/perl -p -i -e "s/hostname = \"localhost\"/hostname = \"${HOSTIPNAME}\"/g" ${CONFIG_FILE}
+    else
+        /usr/bin/perl -p -i -e "s/hostname = \"localhost\"/hostname = \"${FORCE_HOSTNAME}\"/g" ${CONFIG_FILE}
+    fi
+fi
+
+if [ -n "${SEEDS}" ]; then
+    SEEDS=$(eval SEEDS=$SEEDS ; echo $SEEDS | grep '^\".*\"$' || echo "\""$SEEDS"\"" | sed -e 's/, */", "/g')
+    /usr/bin/perl -p -i -e "s/peers = \"\"/peers = [${SEEDS}]/g" ${CONFIG_FILE}
+fi
+
+if [ -n "${REPLI_FACTOR}" ]; then
+    /usr/bin/perl -p -i -e "s/replication = 1/replication = ${REPLI_FACTOR}/g" ${CONFIG_FILE}
+fi
+
+if [ "${SSL_CERT}" == "**None**" ]; then
+    unset SSL_CERT
+fi
+
+if [ "${SSL_SUPPORT}" == "**False**" ]; then
+    unset SSL_SUPPORT
+fi
+
+echo "=> Starting InfluxDB ..."
+
+exec /opt/influxdb/influxd -config=${CONFIG_FILE}

--- a/v0.9.x/run.sh
+++ b/v0.9.x/run.sh
@@ -26,14 +26,6 @@ if [ -n "${REPLI_FACTOR}" ]; then
     /usr/bin/perl -p -i -e "s/replication = 1/replication = ${REPLI_FACTOR}/g" ${CONFIG_FILE}
 fi
 
-if [ "${SSL_CERT}" == "**None**" ]; then
-    unset SSL_CERT
-fi
-
-if [ "${SSL_SUPPORT}" == "**False**" ]; then
-    unset SSL_SUPPORT
-fi
-
 echo "=> Starting InfluxDB ..."
 
 exec /opt/influxdb/influxd -config=${CONFIG_FILE}


### PR DESCRIPTION
This script enables to deploy an influxdb version 0.9.x with clustering a data replication

Tested versions: v0.9 v0.9.1 and v0.9.2

@denderello
